### PR TITLE
fix: 36 @apollon2/server-1.0.0.tgz: 1 vulnerabilities (highest severity is: 7.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2563,9 +2563,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -2587,7 +2587,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -2602,6 +2602,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3762,9 +3766,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -4825,7 +4829,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "express": "4.21.1"
+        "express": "4.21.2"
       },
       "devDependencies": {
         "@types/express": "4.17.21",

--- a/standalone/server/package.json
+++ b/standalone/server/package.json
@@ -9,11 +9,11 @@
     "build": "tsc"
   },
   "dependencies": {
-    "express": "4.21.1"
+    "express": "4.21.2"
   },
   "devDependencies": {
-    "typescript": "5.7.2",
     "@types/express": "4.17.21",
-    "@types/node": "22.10.1"
+    "@types/node": "22.10.1",
+    "typescript": "5.7.2"
   }
 }


### PR DESCRIPTION
This PR solves https://github.com/ls1intum/Apollon2/issues/36

The dependency causing the issue is:
@apollon2/server-1.0.0 -> express@4.21.1 -> path-to-regexp@0.1.10

latest express package v 4.21.2 uses "path-to-regexp": "0.1.12" and this fixes the vulnerabilities