### PR TITLE
48 object diagram extension

### DIFF
--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -29,15 +29,17 @@ import {
 } from "./hooks"
 import { diagramEdgeTypes } from "./edges"
 import "@/styles/app.css"
+import { DiagramType } from "./types"
 
 interface AppProps {
   onReactFlowInit: (instance: ReactFlowInstance) => void
+  diagramType: DiagramType
 }
 
-function App({ onReactFlowInit }: AppProps) {
+function App({ onReactFlowInit, diagramType }: AppProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [edges, , onEdgesChange] = useEdgesState(initialEdges)
-  const { onDrop } = useDrop()
+  const { onDrop } = useDrop(diagramType)
   const { onDragOver } = useDragOver()
   const { onNodeDragStop } = useNodeDragStop(setNodes)
   const { onConnect } = useConnect()
@@ -45,7 +47,7 @@ function App({ onReactFlowInit }: AppProps) {
 
   return (
     <div style={{ display: "flex", width: "100%", height: "100%" }}>
-      <Sidebar />
+      <Sidebar selectedDiagramType={diagramType} />
       <SvgMarkers />
       <ReactFlow
         id="react-flow-library"
@@ -83,10 +85,10 @@ function App({ onReactFlowInit }: AppProps) {
   )
 }
 
-export function AppWithProvider({ onReactFlowInit }: AppProps) {
+export function AppWithProvider({ onReactFlowInit, diagramType }: AppProps) {
   return (
     <ReactFlowProvider>
-      <App onReactFlowInit={onReactFlowInit} />
+      <App onReactFlowInit={onReactFlowInit} diagramType={diagramType} />
     </ReactFlowProvider>
   )
 }

--- a/library/lib/components/Sidebar.tsx
+++ b/library/lib/components/Sidebar.tsx
@@ -1,10 +1,10 @@
-import React, { DragEvent } from "react"
+import React, { DragEvent, FC } from "react"
 import {
-  dropElementConfig,
+  dropElementConfigs,
   transformScale,
 } from "@/constants/dropElementConfig"
 import { DividerLine } from "./DividerLine"
-import { DropNodeData } from "@/types"
+import { DiagramType, DropNodeData } from "@/types"
 
 const onDragStart = (event: DragEvent, { type, data }: DropNodeData) => {
   const rect = (event.target as HTMLElement).getBoundingClientRect()
@@ -20,7 +20,11 @@ const onDragStart = (event: DragEvent, { type, data }: DropNodeData) => {
   event.dataTransfer.effectAllowed = "move"
 }
 
-export const Sidebar = () => {
+interface SidebarProps {
+  selectedDiagramType: DiagramType
+}
+
+export const Sidebar: FC<SidebarProps> = ({ selectedDiagramType }) => {
   return (
     <aside style={{ height: "100%", backgroundColor: "#f0f0f0" }}>
       <div
@@ -31,8 +35,8 @@ export const Sidebar = () => {
           margin: "10px",
         }}
       >
-        {dropElementConfig.map((config) => (
-          <React.Fragment key={`${config.type}_${config.name}`}>
+        {dropElementConfigs[selectedDiagramType].map((config) => (
+          <React.Fragment key={`${config.type}_${config.defaultData.name}`}>
             {/* Add separator before the Color Description */}
             {config.type === "colorDescription" && (
               <DividerLine style={{ margin: "3px 0" }} height={2} />
@@ -59,7 +63,7 @@ export const Sidebar = () => {
                 height: config.height,
                 ...config.defaultData,
                 transformScale,
-                id: "1",
+                id: "2",
               })}
             </div>
           </React.Fragment>

--- a/library/lib/components/index.ts
+++ b/library/lib/components/index.ts
@@ -1,4 +1,4 @@
-export * from "./Text"
+export * from "./svgs/nodes/CustomText"
 export * from "./ThemedElements"
 export * from "./Sidebar"
 export * from "./DividerLine"

--- a/library/lib/components/svgs/nodes/CustomText.tsx
+++ b/library/lib/components/svgs/nodes/CustomText.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { FC } from "react"
 
 type Props = {
   children: React.ReactNode
@@ -13,7 +13,7 @@ type Props = {
   noY?: boolean
 }
 
-export const Text: React.FC<Props & Record<string, unknown>> = ({
+export const CustomText: FC<Props & Record<string, unknown>> = ({
   children,
   fill,
   x = "50%",

--- a/library/lib/components/svgs/nodes/HeaderSection.tsx
+++ b/library/lib/components/svgs/nodes/HeaderSection.tsx
@@ -1,0 +1,50 @@
+import { FC } from "react"
+import { ClassType } from "@/types"
+import { CustomText } from "./CustomText"
+
+interface HeaderSectionProps {
+  showStereotype: boolean
+  stereotype?: ClassType
+  name: string
+  width: number
+  font: string
+  headerHeight: number
+}
+
+export const HeaderSection: FC<HeaderSectionProps> = ({
+  showStereotype,
+  stereotype,
+  name,
+  width,
+  font,
+  headerHeight,
+}) => {
+  return (
+    <g>
+      <CustomText
+        x={width / 2}
+        y={headerHeight / 2}
+        dominantBaseline="middle"
+        textAnchor="middle"
+        font={font}
+        fontWeight="bold"
+        textDecoration={
+          stereotype === ClassType.ObjectClass ? "underline" : "normal"
+        }
+      >
+        {showStereotype && (
+          <tspan x={width / 2} dy="-8" fontSize="85%">
+            {`«${stereotype}»`}
+          </tspan>
+        )}
+        <tspan
+          x={width / 2}
+          dy={showStereotype ? "18" : "0"}
+          fontStyle={stereotype === ClassType.Abstract ? "italic" : "normal"}
+        >
+          {name}
+        </tspan>
+      </CustomText>
+    </g>
+  )
+}

--- a/library/lib/components/svgs/nodes/RowBlockSection.tsx
+++ b/library/lib/components/svgs/nodes/RowBlockSection.tsx
@@ -1,0 +1,35 @@
+import { ExtraElement } from "@/types"
+import { CustomText } from "./CustomText"
+import { FC } from "react"
+
+interface Props {
+  items: ExtraElement[]
+  padding: number
+  itemHeight: number
+  width: number
+  font: string
+  offsetFromTop: number
+}
+
+export const RowBlockSection: FC<Props> = ({
+  items,
+  padding,
+  itemHeight,
+  font,
+  offsetFromTop,
+}) => (
+  <g transform={`translate(0, ${offsetFromTop})`}>
+    {items.map((item, index) => (
+      <CustomText
+        key={item.id}
+        x={padding}
+        y={15 + index * itemHeight}
+        dominantBaseline="middle"
+        textAnchor="start"
+        font={font}
+      >
+        {item.name}
+      </CustomText>
+    ))}
+  </g>
+)

--- a/library/lib/components/svgs/nodes/SeparationLine.tsx
+++ b/library/lib/components/svgs/nodes/SeparationLine.tsx
@@ -1,0 +1,18 @@
+import { LINE_WIDTH } from "@/constants"
+import { FC } from "react"
+
+interface SeparationLineProps {
+  y: number
+  width: number
+}
+
+export const SeparationLine: FC<SeparationLineProps> = ({ y, width }) => (
+  <line
+    x1="0"
+    x2={width}
+    y1={y}
+    y2={y}
+    stroke="black"
+    strokeWidth={LINE_WIDTH}
+  />
+)

--- a/library/lib/components/svgs/nodes/classDiagram/ClassSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/ClassSVG.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useEffect, useMemo } from "react"
 import { ThemedRect } from "@/components/ThemedElements"
-import { Text } from "@/components/Text"
 import { ClassType, ExtraElement } from "@/types"
 import { useReactFlow } from "@xyflow/react"
 import {
@@ -15,9 +14,11 @@ import {
   DEFAULT_METHOD_HEIGHT,
   DEFAULT_PADDING,
   DEFAULT_HEADER_HEIGHT_WITH_STREOTYPE,
-  LINE_WIDTH,
   LINE_WIDTH_ON_EDGE,
 } from "@/constants/dropElementConfig"
+import { SeparationLine } from "@/components/svgs/nodes/SeparationLine"
+import { HeaderSection } from "../HeaderSection"
+import { RowBlockSection } from "../RowBlockSection"
 
 export interface MinSize {
   minWidth: number
@@ -164,13 +165,13 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
             <>
               {/* Separation Line After Header */}
               <SeparationLine y={headerHeight} width={finalWidth} />
-              <AttributesSection
-                attributes={attributes}
+              <RowBlockSection
+                items={attributes}
                 padding={padding}
-                attributeHeight={attributeHeight}
+                itemHeight={attributeHeight}
                 width={finalWidth}
                 font={font}
-                headerHeight={headerHeight}
+                offsetFromTop={headerHeight}
               />
             </>
           )}
@@ -182,14 +183,13 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
                 y={headerHeight + attributes.length * attributeHeight}
                 width={finalWidth}
               />
-              <MethodsSection
-                attributesLength={attributes.length}
-                methods={methods}
+              <RowBlockSection
+                items={methods}
                 padding={padding}
-                methodHeight={methodHeight}
+                itemHeight={methodHeight}
                 width={finalWidth}
                 font={font}
-                headerHeight={headerHeight}
+                offsetFromTop={headerHeight + attributes.length * methodHeight}
               />
             </>
           )}
@@ -197,137 +197,4 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
       </svg>
     )
   }
-)
-
-// Sub-components for better modularity
-
-interface HeaderSectionProps {
-  showStereotype: boolean
-  stereotype?: ClassType
-  name: string
-  width: number
-  font: string
-  headerHeight: number
-}
-
-const HeaderSection: React.FC<HeaderSectionProps> = ({
-  showStereotype,
-  stereotype,
-  name,
-  width,
-  font,
-  headerHeight,
-}) => {
-  return (
-    <g>
-      <Text
-        x={width / 2}
-        y={headerHeight / 2}
-        dominantBaseline="middle"
-        textAnchor="middle"
-        font={font}
-        fontWeight="bold"
-        textDecoration={
-          stereotype === ClassType.ObjectClass ? "underline" : "normal"
-        }
-      >
-        {showStereotype && (
-          <tspan x={width / 2} dy="-8" fontSize="85%">
-            {`«${stereotype}»`}
-          </tspan>
-        )}
-        <tspan
-          x={width / 2}
-          dy={showStereotype ? "18" : "0"}
-          fontStyle={stereotype === ClassType.Abstract ? "italic" : "normal"}
-        >
-          {name}
-        </tspan>
-      </Text>
-    </g>
-  )
-}
-
-interface SeparationLineProps {
-  y: number
-  width: number
-}
-
-const SeparationLine: React.FC<SeparationLineProps> = ({ y, width }) => (
-  <line
-    x1="0"
-    x2={width}
-    y1={y}
-    y2={y}
-    stroke="black"
-    strokeWidth={LINE_WIDTH}
-  />
-)
-
-interface AttributesSectionProps {
-  attributes: ExtraElement[]
-  padding: number
-  attributeHeight: number
-  width: number
-  font: string
-  headerHeight: number
-}
-
-const AttributesSection: React.FC<AttributesSectionProps> = ({
-  attributes,
-  padding,
-  attributeHeight,
-  font,
-  headerHeight,
-}) => (
-  <g transform={`translate(0, ${headerHeight})`}>
-    {attributes.map((attribute, index) => (
-      <Text
-        key={attribute.id}
-        x={padding}
-        y={15 + index * attributeHeight}
-        dominantBaseline="middle"
-        textAnchor="start"
-        font={font}
-      >
-        {attribute.name}
-      </Text>
-    ))}
-  </g>
-)
-
-interface MethodsSectionProps {
-  methods: ExtraElement[]
-  attributesLength: number
-  padding: number
-  methodHeight: number
-  width: number
-  font: string
-  headerHeight: number
-}
-
-const MethodsSection: React.FC<MethodsSectionProps> = ({
-  attributesLength,
-  methods,
-  padding,
-  methodHeight,
-  font,
-  headerHeight,
-}) => (
-  <g
-    transform={`translate(0, ${headerHeight + attributesLength * methodHeight})`}
-  >
-    {methods.map((method, index) => (
-      <Text
-        key={method.id}
-        x={padding}
-        y={15 + index * methodHeight}
-        dominantBaseline="middle"
-        textAnchor="start"
-        font={font}
-      >
-        {method.name}
-      </Text>
-    ))}
-  </g>
 )

--- a/library/lib/components/svgs/nodes/classDiagram/ClassSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/ClassSVG.tsx
@@ -61,7 +61,10 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
     ref
   ) {
     // Layout constants
-    const headerHeight = stereotype
+    const showStereotype = stereotype
+      ? stereotype !== ClassType.ObjectClass
+      : false
+    const headerHeight = showStereotype
       ? DEFAULT_HEADER_HEIGHT_WITH_STREOTYPE
       : DEFAULT_HEADER_HEIGHT
     const attributeHeight = DEFAULT_ATTRIBUTE_HEIGHT
@@ -148,6 +151,7 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
 
           {/* Header Section */}
           <HeaderSection
+            showStereotype={showStereotype}
             stereotype={stereotype}
             name={name}
             width={finalWidth}
@@ -198,6 +202,7 @@ export const ClassSVG = forwardRef<SVGSVGElement, ClassSVGProps>(
 // Sub-components for better modularity
 
 interface HeaderSectionProps {
+  showStereotype: boolean
   stereotype?: ClassType
   name: string
   width: number
@@ -206,36 +211,42 @@ interface HeaderSectionProps {
 }
 
 const HeaderSection: React.FC<HeaderSectionProps> = ({
+  showStereotype,
   stereotype,
   name,
   width,
   font,
   headerHeight,
-}) => (
-  <g>
-    <Text
-      x={width / 2}
-      y={headerHeight / 2}
-      dominantBaseline="middle"
-      textAnchor="middle"
-      font={font}
-      fontWeight="bold"
-    >
-      {stereotype && (
-        <tspan x={width / 2} dy="-8" fontSize="85%">
-          {`«${stereotype}»`}
-        </tspan>
-      )}
-      <tspan
+}) => {
+  return (
+    <g>
+      <Text
         x={width / 2}
-        dy={stereotype ? "18" : "0"}
-        fontStyle={stereotype === ClassType.Abstract ? "italic" : "normal"}
+        y={headerHeight / 2}
+        dominantBaseline="middle"
+        textAnchor="middle"
+        font={font}
+        fontWeight="bold"
+        textDecoration={
+          stereotype === ClassType.ObjectClass ? "underline" : "normal"
+        }
       >
-        {name}
-      </tspan>
-    </Text>
-  </g>
-)
+        {showStereotype && (
+          <tspan x={width / 2} dy="-8" fontSize="85%">
+            {`«${stereotype}»`}
+          </tspan>
+        )}
+        <tspan
+          x={width / 2}
+          dy={showStereotype ? "18" : "0"}
+          fontStyle={stereotype === ClassType.Abstract ? "italic" : "normal"}
+        >
+          {name}
+        </tspan>
+      </Text>
+    </g>
+  )
+}
 
 interface SeparationLineProps {
   y: number

--- a/library/lib/components/svgs/nodes/classDiagram/ColorDescriptionSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/ColorDescriptionSVG.tsx
@@ -1,5 +1,5 @@
 import { ThemedPath } from "@/components/ThemedElements"
-import { Text } from "@/components/Text"
+import { CustomText } from "@/components/svgs/nodes/CustomText"
 import { SVGAttributes } from "react"
 
 export type ColorDescriptionSVGProps = {
@@ -47,7 +47,7 @@ export function ColorDescriptionSVG({
           strokeMiterlimit="10"
         />
         {/* Description Text */}
-        <Text
+        <CustomText
           x={innerWidth / 2}
           y={innerHeight / 2}
           dominantBaseline="middle"
@@ -55,7 +55,7 @@ export function ColorDescriptionSVG({
           fontWeight="600"
         >
           {description}
-        </Text>
+        </CustomText>
       </g>
     </svg>
   )

--- a/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
@@ -1,4 +1,4 @@
-import { Text, SVGComponentProps } from "@/components"
+import { SVGComponentProps, CustomText } from "@/components"
 import { LINE_WIDTH, LINE_WIDTH_ON_EDGE } from "@/constants"
 import { FC, forwardRef, SVGAttributes } from "react"
 
@@ -39,7 +39,7 @@ export const PackageSVG = forwardRef<SVGSVGElement, PackageSVGProps>(
           />
 
           {/* Name Text */}
-          <Text
+          <CustomText
             x={width / 2}
             y={leftTopBoxHeight + padding}
             textAnchor="middle"
@@ -47,7 +47,7 @@ export const PackageSVG = forwardRef<SVGSVGElement, PackageSVGProps>(
             dominantBaseline="hanging"
           >
             {name}
-          </Text>
+          </CustomText>
         </g>
       </svg>
     )

--- a/library/lib/constants/dropElementConfig.tsx
+++ b/library/lib/constants/dropElementConfig.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ClassSVG, PackageSVG, ColorDescriptionSVG } from "@/components"
+import { ClassSVG, PackageSVG } from "@/components"
 import { generateUUID } from "@/utils"
-import { ClassType } from "@/types"
+import { ClassType, DiagramType } from "@/types"
 import { DiagramNodeTypeKeys } from "@/nodes"
 
 export * from "./layoutConstants"
@@ -9,83 +9,92 @@ export const transformScale = 0.8
 
 const droppedElementWidth = 160
 
-export const dropElementConfig: {
+export type DropElementConfig = {
   type: DiagramNodeTypeKeys
-  name: string
   width: number
   height: number
   defaultData: Record<string, unknown>
   svg: React.FC<any>
-}[] = [
-  {
-    type: "package",
-    name: "Package",
-    width: droppedElementWidth,
-    height: 120,
-    defaultData: { name: "Package" },
-    svg: (props) => <PackageSVG {...props} />,
-  },
-  {
-    type: "class",
-    name: "Class",
-    width: droppedElementWidth,
-    height: 100,
-    defaultData: {
-      name: "Class",
-      methods: [{ id: generateUUID(), name: "+ method()" }],
-      attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+}
+
+export const dropElementConfigs: Record<DiagramType, DropElementConfig[]> = {
+  [DiagramType.ClassDiagram]: [
+    {
+      type: "package",
+
+      width: droppedElementWidth,
+      height: 120,
+      defaultData: { name: "Package" },
+      svg: (props) => <PackageSVG {...props} />,
     },
-    svg: (props) => <ClassSVG {...props} />,
-  },
-  {
-    type: "class",
-    name: "Abstract",
-    width: droppedElementWidth,
-    height: 110,
-    defaultData: {
-      name: "Abstract",
-      stereotype: ClassType.Abstract,
-      methods: [{ id: generateUUID(), name: "+ method()" }],
-      attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+    {
+      type: "class",
+      width: droppedElementWidth,
+      height: 100,
+      defaultData: {
+        name: "Class",
+
+        methods: [{ id: generateUUID(), name: "+ method()" }],
+        attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+      },
+      svg: (props) => <ClassSVG {...props} />,
     },
-    svg: (props) => <ClassSVG {...props} />,
-  },
-  {
-    type: "class",
-    name: "Enumeration",
-    width: droppedElementWidth,
-    height: 140,
-    defaultData: {
-      name: "Enumeration",
-      stereotype: ClassType.Enumeration,
-      methods: [],
-      attributes: [
-        { id: generateUUID(), name: "Case 1" },
-        { id: generateUUID(), name: "Case 2" },
-        { id: generateUUID(), name: "Case 3" },
-      ],
+    {
+      type: "class",
+      width: droppedElementWidth,
+      height: 110,
+      defaultData: {
+        name: "Abstract",
+        stereotype: ClassType.Abstract,
+        methods: [{ id: generateUUID(), name: "+ method()" }],
+        attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+      },
+      svg: (props) => <ClassSVG {...props} />,
     },
-    svg: (props) => <ClassSVG {...props} />,
-  },
-  {
-    type: "class",
-    name: "Interface",
-    width: droppedElementWidth,
-    height: 110,
-    defaultData: {
-      name: "Interface",
-      stereotype: ClassType.Interface,
-      methods: [{ id: generateUUID(), name: "+ method()" }],
-      attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+    {
+      type: "class",
+
+      width: droppedElementWidth,
+      height: 140,
+      defaultData: {
+        name: "Enumeration",
+        stereotype: ClassType.Enumeration,
+        methods: [],
+        attributes: [
+          { id: generateUUID(), name: "Case 1" },
+          { id: generateUUID(), name: "Case 2" },
+          { id: generateUUID(), name: "Case 3" },
+        ],
+      },
+      svg: (props) => <ClassSVG {...props} />,
     },
-    svg: (props) => <ClassSVG {...props} />,
-  },
-  {
-    type: "colorDescription",
-    name: "Color Description",
-    width: droppedElementWidth,
-    height: 48,
-    defaultData: { description: "Color Description" },
-    svg: (props) => <ColorDescriptionSVG {...props} />,
-  },
-]
+    {
+      type: "class",
+
+      width: droppedElementWidth,
+      height: 110,
+      defaultData: {
+        name: "Interface",
+        stereotype: ClassType.Interface,
+        methods: [{ id: generateUUID(), name: "+ method()" }],
+        attributes: [{ id: generateUUID(), name: "+ attribute: Type" }],
+      },
+      svg: (props) => <ClassSVG {...props} />,
+    },
+  ],
+  [DiagramType.ObjectDiagram]: [
+    {
+      type: "class",
+
+      width: droppedElementWidth,
+      height: 70,
+      defaultData: {
+        name: "Object",
+        stereotype: ClassType.ObjectClass,
+        attributes: [{ id: generateUUID(), name: "attribute = value" }],
+        methods: [],
+      },
+      svg: (props) => <ClassSVG {...props} />,
+    },
+  ],
+}

--- a/library/lib/hooks/useDragDrop.ts
+++ b/library/lib/hooks/useDragDrop.ts
@@ -1,10 +1,10 @@
-import { dropElementConfig } from "@/constants/dropElementConfig"
-import { DropNodeData } from "@/types"
+import { dropElementConfigs } from "@/constants/dropElementConfig"
+import { DiagramType, DropNodeData } from "@/types"
 import { generateUUID } from "@/utils"
 import { useReactFlow, type Node } from "@xyflow/react"
 import { useCallback, DragEvent } from "react"
 
-export const useDragDrop = () => {
+export const useDragDrop = (selectedDiagramType: DiagramType) => {
   const { screenToFlowPosition, setNodes } = useReactFlow()
 
   const onDrop = useCallback(
@@ -14,7 +14,7 @@ export const useDragDrop = () => {
         event.dataTransfer.getData("text/plain")
       ) as DropNodeData
 
-      const config = dropElementConfig.find(
+      const config = dropElementConfigs[selectedDiagramType].find(
         (config) => config.type === dropData.type
       )
       // Validate the dropped element type

--- a/library/lib/hooks/useDrop.ts
+++ b/library/lib/hooks/useDrop.ts
@@ -1,11 +1,11 @@
-import { dropElementConfig } from "@/constants"
+import { dropElementConfigs } from "@/constants"
 import { MOUSE_UP_OFFSET_IN_PIXELS } from "@/constants"
-import { DropNodeData } from "@/types"
+import { DiagramType, DropNodeData } from "@/types"
 import { generateUUID, getPositionOnCanvas, resizeAllParents } from "@/utils"
 import { useReactFlow, type Node } from "@xyflow/react"
 import { useCallback, DragEvent } from "react"
 
-export const useDrop = () => {
+export const useDrop = (selectedDiagramType: DiagramType) => {
   const { screenToFlowPosition, setNodes, getIntersectingNodes, getNodes } =
     useReactFlow()
 
@@ -16,7 +16,7 @@ export const useDrop = () => {
         event.dataTransfer.getData("text/plain")
       ) as DropNodeData
 
-      const config = dropElementConfig.find(
+      const config = dropElementConfigs[selectedDiagramType].find(
         (config) => config.type === dropData.type
       )
       // Validate the dropped element type

--- a/library/lib/index.tsx
+++ b/library/lib/index.tsx
@@ -8,16 +8,28 @@ import {
   exportAsJSON,
   validateParsedJSON,
 } from "./utils"
+import { DiagramType } from "./types"
 
+export * from "./types"
 export class Apollon2 {
   private root: ReactDOM.Root | null = null
   private reactFlowInstance: ReactFlowInstance | null = null
+  private diagramType: DiagramType = DiagramType.ClassDiagram
 
   constructor(element: HTMLElement) {
     this.root = ReactDOM.createRoot(element)
-    this.root.render(
-      <AppWithProvider onReactFlowInit={this.setReactFlowInstance.bind(this)} />
-    )
+    this.renderApp()
+  }
+
+  private renderApp() {
+    if (this.root) {
+      this.root.render(
+        <AppWithProvider
+          onReactFlowInit={this.setReactFlowInstance.bind(this)}
+          diagramType={this.diagramType} // Pass the diagramType directly as a prop
+        />
+      )
+    }
   }
 
   private setReactFlowInstance(instance: ReactFlowInstance) {
@@ -103,6 +115,21 @@ export class Apollon2 {
       return true
     } else {
       return "ReactFlowInstance is not available for importing JSON."
+    }
+  }
+
+  public createNewDiagram(diagramType: DiagramType) {
+    this.diagramType = diagramType
+    // Trigger a re-render by calling renderApp after updating the diagramType
+    this.renderApp()
+
+    if (this.reactFlowInstance) {
+      this.reactFlowInstance.setNodes([])
+      this.reactFlowInstance.setEdges([])
+    } else {
+      console.error(
+        "ReactFlowInstance is not available for creating new diagram"
+      )
     }
   }
 }

--- a/library/lib/index.tsx
+++ b/library/lib/index.tsx
@@ -36,6 +36,14 @@ export class Apollon2 {
     this.reactFlowInstance = instance
   }
 
+  private deSelectAllNodes = () => {
+    if (this.reactFlowInstance) {
+      this.reactFlowInstance.setNodes((nodes) =>
+        nodes.map((node) => ({ ...node, selected: false }))
+      )
+    }
+  }
+
   public getNodes(): Node[] {
     return this.reactFlowInstance ? this.reactFlowInstance.getNodes() : []
   }
@@ -60,6 +68,7 @@ export class Apollon2 {
 
   public exportAsJson(diagramName: string) {
     if (this.reactFlowInstance) {
+      this.deSelectAllNodes()
       exportAsJSON(diagramName, this.diagramType, this.reactFlowInstance)
     } else {
       console.error("ReactFlowInstance is not available for exporting JSON.")
@@ -71,6 +80,7 @@ export class Apollon2 {
     isBackgroundTransparent: boolean = false
   ) {
     if (this.reactFlowInstance) {
+      this.deSelectAllNodes()
       exportAsPNG(diagramName, this.reactFlowInstance, isBackgroundTransparent)
     } else {
       console.error("ReactFlowInstance is not available for exporting PNG.")
@@ -79,6 +89,7 @@ export class Apollon2 {
 
   public exportImageAsSVG(diagramName: string) {
     if (this.reactFlowInstance) {
+      this.deSelectAllNodes()
       exportAsSVG(diagramName, this.reactFlowInstance)
     } else {
       console.error("ReactFlowInstance is not available for exporting SVG.")
@@ -87,6 +98,7 @@ export class Apollon2 {
 
   public exportImageAsPDF(diagramName: string) {
     if (this.reactFlowInstance) {
+      this.deSelectAllNodes()
       exportAsPDF(diagramName, this.reactFlowInstance)
     } else {
       console.error("ReactFlowInstance is not available for exporting PDF.")

--- a/library/lib/index.tsx
+++ b/library/lib/index.tsx
@@ -60,7 +60,7 @@ export class Apollon2 {
 
   public exportAsJson(diagramName: string) {
     if (this.reactFlowInstance) {
-      exportAsJSON(diagramName, this.reactFlowInstance)
+      exportAsJSON(diagramName, this.diagramType, this.reactFlowInstance)
     } else {
       console.error("ReactFlowInstance is not available for exporting JSON.")
     }
@@ -104,8 +104,11 @@ export class Apollon2 {
         return result
       }
 
-      const { nodes, edges } = result
+      const { nodes, edges, diagramType } = result
 
+      this.diagramType = diagramType
+      // Trigger a re-render by calling renderApp after updating the diagramType
+      this.renderApp()
       this.reactFlowInstance.setNodes(nodes)
       this.reactFlowInstance.setEdges(edges)
       // We need to render the nodes and edges first before fitting the view

--- a/library/lib/types/DiagramType.ts
+++ b/library/lib/types/DiagramType.ts
@@ -1,0 +1,4 @@
+export enum DiagramType {
+  ClassDiagram,
+  ObjectDiagram,
+}

--- a/library/lib/types/DiagramType.ts
+++ b/library/lib/types/DiagramType.ts
@@ -1,4 +1,4 @@
 export enum DiagramType {
-  ClassDiagram,
-  ObjectDiagram,
+  ClassDiagram = "ClassDiagram",
+  ObjectDiagram = "ObjectDiagram",
 }

--- a/library/lib/types/ParsedJson.ts
+++ b/library/lib/types/ParsedJson.ts
@@ -1,0 +1,10 @@
+import { type Edge, type Node } from "@xyflow/react"
+import { DiagramType } from "./DiagramType"
+
+export type ParsedJSON = {
+  version: string
+  title: string
+  diagramType: DiagramType
+  nodes: Node[]
+  edges: Edge[]
+}

--- a/library/lib/types/index.ts
+++ b/library/lib/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./nodes"
 export * from "./locationPopover"
+export * from "./DiagramType"

--- a/library/lib/types/nodes/enums/ClassType.ts
+++ b/library/lib/types/nodes/enums/ClassType.ts
@@ -2,4 +2,5 @@ export enum ClassType {
   Abstract = "Abstract",
   Interface = "Interface",
   Enumeration = "Enumeration",
+  ObjectClass = "ObjectClass",
 }

--- a/library/lib/utils/exportUtils.ts
+++ b/library/lib/utils/exportUtils.ts
@@ -9,6 +9,8 @@ import {
 import { toPng, toSvg } from "html-to-image"
 import jsPDF from "jspdf"
 import { ExportFileFormat } from "../enums"
+import { ParsedJSON } from "@/types/ParsedJson"
+import { DiagramType } from "@/types"
 
 // Calculate dimensions based on nodes and viewport
 const calculateDimensions = (
@@ -92,11 +94,13 @@ const downloadImage = (
 // Export the diagram as JSON
 export const exportAsJSON = (
   diagramName: string,
+  diagramType: DiagramType,
   reactFlowInstance: ReactFlowInstance<Node, Edge>
 ) => {
-  const data = {
+  const data: ParsedJSON = {
     version: "apollon2",
     title: diagramName,
+    diagramType,
     nodes: reactFlowInstance.getNodes(),
     edges: reactFlowInstance.getEdges(),
   }

--- a/library/lib/utils/importUtils.ts
+++ b/library/lib/utils/importUtils.ts
@@ -1,11 +1,5 @@
-import { type Edge, type Node } from "@xyflow/react"
-
-type ParsedJSON = {
-  version: string
-  title: string
-  nodes: Node[]
-  edges: Edge[]
-}
+import { DiagramType } from "@/types"
+import { ParsedJSON } from "@/types/ParsedJson"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const validateParsedJSON = (json: any): ParsedJSON | string => {
@@ -14,10 +8,16 @@ export const validateParsedJSON = (json: any): ParsedJSON | string => {
     json === null ||
     typeof json.version !== "string" ||
     typeof json.title !== "string" ||
+    typeof json.diagramType !== "string" ||
     !Array.isArray(json.nodes) ||
     !Array.isArray(json.edges)
   ) {
     return "Invalid JSON structure. Required fields: version, title, nodes, edges."
+  }
+
+  //Validate diagramType
+  if (!(json.diagramType in DiagramType)) {
+    return "Invalid diagram type"
   }
 
   // Validate nodes

--- a/standalone/webapp/src/components/modals/NewDiagramFromTemplateModal.tsx
+++ b/standalone/webapp/src/components/modals/NewDiagramFromTemplateModal.tsx
@@ -16,7 +16,6 @@ const style = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  bgcolor: "background.paper",
   display: "flex",
   flex: 1,
   flexDirection: "column",

--- a/standalone/webapp/src/components/modals/NewDiagramModal.tsx
+++ b/standalone/webapp/src/components/modals/NewDiagramModal.tsx
@@ -3,30 +3,69 @@ import Typography from "@mui/material/Typography"
 import Modal from "@mui/material/Modal"
 import { useApollon2Context } from "@/contexts"
 import { useState } from "react"
-import TextField from "@mui/material/TextField/TextField"
-import Button from "@mui/material/Button/Button"
+import TextField from "@mui/material/TextField"
+import Button from "@mui/material/Button"
 import { useModalContext } from "@/contexts/ModalContext"
+import { DiagramType } from "@apollon2/library"
+import CloseOutlinedIcon from "@mui/icons-material/CloseOutlined"
+import Paper from "@mui/material/Paper"
+import Divider from "@mui/material/Divider"
 
 const style = {
   position: "absolute",
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  bgcolor: "background.paper",
-  border: "2px solid #000",
-  boxShadow: 24,
-  p: 2,
   display: "flex",
   flex: 1,
   flexDirection: "column",
-  minWidth: 300,
+  minWidth: 350,
   gap: 1,
+}
+
+const diagramTypes = {
+  structural: [DiagramType.ClassDiagram, DiagramType.ObjectDiagram],
+  behavioral: [],
+}
+
+const diagramTypeToTitle = {
+  [DiagramType.ClassDiagram]: "Class Diagram",
+  [DiagramType.ObjectDiagram]: "Object Diagram",
 }
 
 export const NewDiagramModal = () => {
   const { apollon2, setDiagramName } = useApollon2Context()
   const { closeModal } = useModalContext()
-  const [newDiagramName, setNewDiagramName] = useState("")
+  const [isDiagramNameDefault, setIsDiagramNameDefault] =
+    useState<boolean>(true)
+  const [newDiagramName, setNewDiagramName] = useState<string>("Class Diagram")
+  const [selectedDiagramType, setSelectedDiagramType] = useState<DiagramType>(
+    DiagramType.ClassDiagram
+  )
+
+  const handleCreateDiagram = () => {
+    setDiagramName(newDiagramName)
+    apollon2?.createNewDiagram(selectedDiagramType)
+    closeModal()
+  }
+
+  const handleSelectDiagramType = (type: DiagramType) => {
+    setSelectedDiagramType(type)
+  }
+
+  const handleDiagramNameChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setNewDiagramName(event.target.value)
+    setIsDiagramNameDefault(false)
+  }
+
+  const handleDiagramTypeChange = (type: DiagramType) => {
+    setSelectedDiagramType(type)
+    if (isDiagramNameDefault) {
+      setNewDiagramName(diagramTypeToTitle[type])
+    }
+  }
 
   return (
     <Modal
@@ -35,30 +74,122 @@ export const NewDiagramModal = () => {
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
     >
-      <Box sx={style}>
-        <Box>
-          <Typography id="modal-modal-title" variant="h6" component="h2">
-            Create new diagram
+      <Paper sx={style}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            p: 2,
+          }}
+        >
+          <Typography variant="h5" id="modal-modal-title">
+            Create new Diagram
           </Typography>
-          <TextField
-            fullWidth
-            value={newDiagramName}
-            onChange={(event) => setNewDiagramName(event.target.value)}
-          />
-        </Box>
-        <Box sx={{ display: "flex", justifyContent: "flex-end", flex: 1 }}>
-          <Button
-            variant="contained"
-            onClick={() => {
-              setDiagramName(newDiagramName)
-              closeModal()
-              apollon2?.resetDiagram()
-            }}
-          >
-            Create
+          <Button variant="text" onClick={closeModal} size="small">
+            <CloseOutlinedIcon style={{ color: "gray" }} />
           </Button>
         </Box>
-      </Box>
+        <Divider />
+
+        <Box
+          sx={{
+            px: 2,
+            pb: 2,
+            gap: 2,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {/* Diagram Title */}
+          <Box>
+            <Typography
+              variant="body2"
+              component="label"
+              htmlFor="diagram-title"
+              className="form-label"
+            >
+              Diagram Title
+            </Typography>
+            <TextField
+              fullWidth
+              id="diagram-title"
+              value={newDiagramName}
+              onChange={handleDiagramNameChange}
+              placeholder="Enter diagram title"
+              variant="outlined"
+            />
+          </Box>
+
+          {/* Diagram Type Selection */}
+          <Box>
+            <Box className="card">
+              <Typography variant="h6" className="card-header">
+                Structural Diagrams
+              </Typography>
+              <Box
+                className="list-group list-group-flush"
+                sx={{ gap: 1, flexDirection: "column", display: "flex" }}
+              >
+                {diagramTypes.structural.map((type) => (
+                  <Button
+                    key={type}
+                    onClick={() => handleDiagramTypeChange(type)}
+                    onDoubleClick={handleCreateDiagram}
+                    variant={
+                      selectedDiagramType === type ? "contained" : "outlined"
+                    }
+                    style={{ justifyContent: "flex-start" }}
+                    className={`list-group-item list-group-item-action `}
+                  >
+                    {diagramTypeToTitle[type]}
+                  </Button>
+                ))}
+              </Box>
+            </Box>
+            {/* Behavioral Diagrams */}
+            {diagramTypes.behavioral.length > 0 && (
+              <Box className="card mt-2">
+                <Typography variant="h6" className="card-header">
+                  Behavioral Diagrams
+                </Typography>
+                <Box className="list-group list-group-flush">
+                  {diagramTypes.behavioral.map((type) => (
+                    <Button
+                      key={type}
+                      onClick={() => handleSelectDiagramType(type)}
+                      className={`list-group-item list-group-item-action ${
+                        selectedDiagramType === type ? "active" : ""
+                      }`}
+                    >
+                      {diagramTypeToTitle[type]}
+                    </Button>
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </Box>
+
+          {/* Footer with buttons */}
+          <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+            <Button
+              variant="contained"
+              onClick={closeModal}
+              sx={{ bgcolor: "gray", textTransform: "none" }}
+            >
+              Close
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleCreateDiagram}
+              sx={{ textTransform: "none" }}
+            >
+              Create Diagram
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
     </Modal>
   )
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
User can create Object diagrams

This PR completes https://github.com/ls1intum/Apollon2/issues/48

### Description

<!-- Describe your changes in detail -->
Dropped element configuration is updated to cover more diagram types
The library can handle more diagram types
New diagrams can be created in different types


### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a new diagram as an Object Diagram
2. Edit it
3. Export it
4. Create a new diagram
5. Import exported diagram
6. See new diagram extension

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://github.com/user-attachments/assets/b6089687-38a7-4ef8-b1d8-2d342f6ae783


