### PR TITLE
feat: improve minimap ux

### DIFF
--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -12,6 +12,7 @@ import {
   Sidebar,
   SvgMarkers,
 } from "@/components"
+import "@xyflow/react/dist/style.css"
 import "@/styles/app.css"
 import { useDiagramStore, useMetadataStore } from "./store/context"
 import { useShallow } from "zustand/shallow"

--- a/library/lib/components/CustomMiniMap.tsx
+++ b/library/lib/components/CustomMiniMap.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
 import { MiniMap, MiniMapNodeProps, Panel, useReactFlow } from "@xyflow/react"
-import ZoomOutMapIcon from "@mui/icons-material/ZoomOutMap"
 import { ClassSVG, PackageSVG } from "./svgs"
+import SouthEastIcon from "@mui/icons-material/SouthEast"
+import MapIcon from "@mui/icons-material/Map"
 
 export const CustomMiniMap = () => {
   const [minimapCollapsed, setMinimapCollapsed] = useState(true)
@@ -9,24 +10,52 @@ export const CustomMiniMap = () => {
   if (minimapCollapsed) {
     return (
       <Panel position="bottom-right" onClick={() => setMinimapCollapsed(false)}>
-        <ZoomOutMapIcon />
+        <MapIcon />
       </Panel>
     )
   }
 
   return (
-    <MiniMap
-      zoomable
+    <Panel
+      position="bottom-right"
       onClick={() => setMinimapCollapsed(true)}
-      nodeComponent={MiniMapNode}
-    />
+      style={{ boxShadow: "none", backgroundColor: "transparent" }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          right: 0,
+          display: "flex",
+          zIndex: 10,
+          padding: 8,
+          backgroundColor: "white",
+          borderRadius: "4px",
+          justifyContent: "center",
+          alignItems: "center",
+          cursor: "pointer",
+          boxShadow: "0 0 4px 0 rgb(0 0 0 / 0.2)",
+        }}
+      >
+        <SouthEastIcon width={16} height={16} />
+      </div>
+
+      <MiniMap
+        zoomable
+        onClick={() => setMinimapCollapsed(true)}
+        nodeComponent={MiniMapNode}
+        offsetScale={20}
+        style={{ zIndex: 5 }}
+      />
+    </Panel>
   )
 }
 
 function MiniMapNode({ id, x, y }: MiniMapNodeProps) {
   const { getNode } = useReactFlow()
 
-  const nodeInfo = getNode(id)!
+  const nodeInfo = getNode(id)
+  if (!nodeInfo) return null
 
   switch (nodeInfo.type) {
     case "class":

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -23,13 +23,6 @@ body {
   --xy-edge-stroke: black;
 }
 
-.react-flow.dark {
-  --background: #0f172a;
-  --panel-background: #1e293b;
-  --panel-shadow: 0 0 8px 0 rgb(0 0 0 / 0.4);
-  --text: #fafafa;
-}
-
 .react-flow__panel,
 .react-flow__node-toolbar {
   background-color: var(--panel-background);
@@ -133,6 +126,11 @@ body {
 
 .react-flow__node {
   z-index: 9998;
+}
+
+.react-flow__minimap-mask {
+  fill: "#f2f2f2";
+  opacity: 0.6;
 }
 
 .prevent-select {

--- a/standalone/webapp/src/App.tsx
+++ b/standalone/webapp/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Route, Routes } from "react-router"
 import { AppProviders } from "./AppProviders"
 import { Navbar } from "./components"
-import "@xyflow/react/dist/style.css"
 import { Apollon, ApollonWithConnection, ErrorPage } from "@/pages"
 import { SafeArea } from "capacitor-plugin-safe-area"
 import { ToastContainer } from "react-toastify"


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Users were confused by the closing of the minimap. It wasn't clear before that minimap is collapsable. 
Some people didn't understand it was a minimap

This PR completes https://github.com/ls1intum/Apollon2/issues/155

### Description

<!-- Describe your changes in detail -->
The minimap icon is updated
Icon is added to close minimap so from UI change, people can understand minimap is collapsible

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Open and Close Minimap

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


https://github.com/user-attachments/assets/2868b4fb-a3c8-4621-8f68-d72bbbfef6f2
