### PR TITLE
feat: update yjs update data to string to send stringified data throu…

### DIFF
--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -269,12 +269,12 @@ export class ApollonEditor {
     }
   }
 
-  public sendBroadcastMessage(sendFn: (data: Uint8Array) => void) {
+  public sendBroadcastMessage(sendFn: (base64Data: string) => void) {
     this.syncManager.setSendFunction(sendFn)
   }
 
-  public receiveBroadcastedMessage(update: Uint8Array) {
-    this.syncManager.handleReceivedData(update)
+  public receiveBroadcastedMessage(base64Data: string) {
+    this.syncManager.handleReceivedData(base64Data)
   }
 
   public updateDiagramTitle(name: string) {
@@ -312,4 +312,5 @@ export class ApollonEditor {
   public addOrUpdateAssessment(assessment: Apollon.Assessment): void {
     this.diagramStore.getState().addOrUpdateAssessment(assessment)
   }
+  public uint8ToBase64 = YjsSyncClass.uint8ToBase64
 }

--- a/standalone/server/src/relaySocketServer.ts
+++ b/standalone/server/src/relaySocketServer.ts
@@ -44,13 +44,22 @@ export const startSocketServer = (): void => {
 
     ws.on("message", (message: WebSocket.RawData) => {
       const clients = diagrams.get(ws.diagramId!)
-
       if (!clients) return
+
+      // Convert message to string if it's a Buffer or string
+      // This is necessary because WebSocket messages can be sent as Buffer or string
+      // and we want to ensure we send a string to all clients
+      const messageString =
+        typeof message === "string"
+          ? message
+          : message instanceof Buffer
+            ? message.toString("utf-8")
+            : ""
 
       let count = 0
       clients.forEach((client) => {
         if (client !== ws && client.readyState === WebSocket.OPEN) {
-          client.send(message)
+          client.send(messageString)
           count++
         }
       })

--- a/standalone/webapp/src/types/WebSocketMessage.ts
+++ b/standalone/webapp/src/types/WebSocketMessage.ts
@@ -1,0 +1,4 @@
+export type WebSocketMessage = {
+  // new fields can be added like collaborators name-color, etc.
+  diagramData: string
+}

--- a/standalone/webapp/src/types/index.ts
+++ b/standalone/webapp/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./ModalTypes"
+export * from "./WebSocketMessage"


### PR DESCRIPTION


<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Artemis uses JSON.stringify to transfer data through websocket. 
Uint8Array is not stringifiable, and extra steps are required to convert this data into base64.
Instead of doing this translation in Artemis side, I decided to do it in the library so the webscoket transferred data can always be stringifiable.
We can also use the advantage of this in a standalone mode, like creating a Collaborators board in the top navigation bar

### Description

<!-- Describe your changes in detail -->
User Window function btoa and atob to convert from Uint8 to string 

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a collaboration diagram
2. Collaborate it from different users
3. See collaboration is working

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->



https://github.com/user-attachments/assets/628640a8-e9f1-4793-a985-7ae53bcffe02


