### PR TITLE
chore: move generating initial sync message logic to library

### DIFF
--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -312,5 +312,9 @@ export class ApollonEditor {
   public addOrUpdateAssessment(assessment: Apollon.Assessment): void {
     this.diagramStore.getState().addOrUpdateAssessment(assessment)
   }
-  public uint8ToBase64 = YjsSyncClass.uint8ToBase64
+
+  static generateInitialSyncMessage(): string {
+    const syncMessage = new Uint8Array(new Uint8Array([0]))
+    return YjsSyncClass.uint8ToBase64(syncMessage)
+  }
 }

--- a/standalone/webapp/src/pages/ApollonWithConnection.tsx
+++ b/standalone/webapp/src/pages/ApollonWithConnection.tsx
@@ -132,11 +132,10 @@ export const ApollonWithConnection: React.FC = () => {
                 }
               })
 
-              const initialSyncMessageInUintArray = instance?.uint8ToBase64(
-                new Uint8Array([0])
-              )
+              const initialSyncMessage =
+                ApollonEditor.generateInitialSyncMessage()
               const initialMessage = JSON.stringify({
-                diagramData: initialSyncMessageInUintArray,
+                diagramData: initialSyncMessage,
               })
               websocketRef.current?.send(initialMessage)
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
No ticket

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Creating initial sync logic is related to the library part of how to consume,
this generating logic should be in the library side

