### PR TITLE
fix: deselect after deleting an item

### DIFF
--- a/library/lib/store/diagramStore.ts
+++ b/library/lib/store/diagramStore.ts
@@ -207,6 +207,15 @@ export const createDiagramStore = (
               if (change.type === "add" || change.type === "replace") {
                 getNodesMap(ydoc).set(change.item.id, change.item)
               } else if (change.type === "remove") {
+                set(
+                  (state) => ({
+                    selectedElementIds: state.selectedElementIds.filter(
+                      (id) => id !== change.id
+                    ),
+                  }),
+                  undefined,
+                  "onNodesChange-remove"
+                )
                 const deletedNode = getNodesMap(ydoc).get(change.id)
                 if (deletedNode) {
                   const connectedEdges = getConnectedEdges(
@@ -286,6 +295,15 @@ export const createDiagramStore = (
               if (change.type === "add" || change.type === "replace") {
                 getEdgesMap(ydoc).set(change.item.id, change.item)
               } else if (change.type === "remove") {
+                set(
+                  (state) => ({
+                    selectedElementIds: state.selectedElementIds.filter(
+                      (id) => id !== change.id
+                    ),
+                  }),
+                  undefined,
+                  "onNodesChange-remove"
+                )
                 getEdgesMap(ydoc).delete(change.id)
               }
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

No ticket bug fix 

### Motivation and Context

fix new selectedelements list update after deleting of an node or edge
it was still in the selected elements list

### Description

<!-- Describe your changes in detail -->

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. ...

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<table>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/579613fe-cf67-47be-b614-0a66b38211ec


</td>
<td>

https://github.com/user-attachments/assets/54733f6f-551f-4712-844c-cecb039ce034


</td>
</tr>
</table>
