### PR TITLE
feat: schedule renovate to create group prs to make less noise in PRs list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "schedule": ["* 20 * * 6"],
+  "timezone": "Europe/Berlin",
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "minor and patch dependencies",
+      "groupSlug": "minor-patch",
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major dependencies",
+      "groupSlug": "major"
+    }
+  ]
 }


### PR DESCRIPTION
# Add Renovate for Dependency Updates

This PR adds Renovate to automate dependency updates in our monorepo.

## Config
- **Schedule**: Runs Saturdays at 20:00 Berlin time.
- **PRs**:
  - Groups `minor`/`patch` updates in one PR ("minor and patch dependencies", branch: `renovate/minor-patch`), automerged after CI.
  - Groups `major` updates in a separate PR ("major dependencies", branch: `renovate/major`) for manual review.
- Uses `config:recommended` for Dependency Dashboard and monorepo support.

## Why
- Keeps dependencies up-to-date.
- Minimizes noise with weekly runs and grouped PRs.

