### PR TITLE
feat: add assessment icons to BPMN elments

### DIFF
--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNAnnotationNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNAnnotationNodeSVG.tsx
@@ -1,10 +1,23 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNAnnotationNodeSVG: React.FC<
   SVGComponentProps & { name: string }
-> = ({ width, height, name, svgAttributes, transformScale }) => {
+> = ({
+  width,
+  height,
+  name,
+  svgAttributes,
+  transformScale,
+  id,
+  showAssessmentResults = false,
+}) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -30,6 +43,10 @@ export const BPMNAnnotationNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNDataObjectNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNDataObjectNodeSVG.tsx
@@ -1,10 +1,23 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNDataObjectNodeSVG: React.FC<
   SVGComponentProps & { name: string }
-> = ({ width, height, name, svgAttributes, transformScale }) => {
+> = ({
+  width,
+  height,
+  name,
+  svgAttributes,
+  transformScale,
+  id,
+  showAssessmentResults = false,
+}) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -31,6 +44,10 @@ export const BPMNDataObjectNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNDataStoreNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNDataStoreNodeSVG.tsx
@@ -1,10 +1,23 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNDataStoreNodeSVG: React.FC<
   SVGComponentProps & { name: string }
-> = ({ width, height, name, svgAttributes, transformScale }) => {
+> = ({
+  width,
+  height,
+  name,
+  svgAttributes,
+  transformScale,
+  id,
+  showAssessmentResults = false,
+}) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -51,6 +64,10 @@ export const BPMNDataStoreNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNEventNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNEventNodeSVG.tsx
@@ -1,6 +1,9 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 import {
   BPMNStartEventType,
   BPMNIntermediateEventType,
@@ -23,7 +26,11 @@ export const BPMNEventNodeSVG: React.FC<BPMNEventNodeSVGProps> = ({
   transformScale,
   variant,
   eventType,
+  id,
+  showAssessmentResults = false,
 }) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
   const r = Math.min(width, height) / 2
@@ -322,6 +329,10 @@ export const BPMNEventNodeSVG: React.FC<BPMNEventNodeSVGProps> = ({
         >
           {name}
         </CustomText>
+      )}
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
       )}
     </svg>
   )

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNGatewayNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNGatewayNodeSVG.tsx
@@ -1,5 +1,8 @@
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 import { BPMNGatewayType } from "@/types"
 import { CustomText } from "@/components"
 
@@ -12,7 +15,11 @@ export const BPMNGatewayNodeSVG: React.FC<
   svgAttributes,
   transformScale,
   gatewayType = "exclusive",
+  id,
+  showAssessmentResults = false,
 }) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -157,6 +164,10 @@ export const BPMNGatewayNodeSVG: React.FC<
         >
           {name}
         </CustomText>
+      )}
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
       )}
     </svg>
   )

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNGroupNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNGroupNodeSVG.tsx
@@ -1,10 +1,23 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNGroupNodeSVG: React.FC<
   SVGComponentProps & { name: string }
-> = ({ width, height, name, svgAttributes, transformScale }) => {
+> = ({
+  width,
+  height,
+  name,
+  svgAttributes,
+  transformScale,
+  id,
+  showAssessmentResults = false,
+}) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -37,6 +50,10 @@ export const BPMNGroupNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNPoolNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNPoolNodeSVG.tsx
@@ -1,10 +1,23 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNPoolNodeSVG: React.FC<
   SVGComponentProps & { name: string }
-> = ({ width, height, name, svgAttributes, transformScale }) => {
+> = ({
+  width,
+  height,
+  name,
+  svgAttributes,
+  transformScale,
+  id,
+  showAssessmentResults = false,
+}) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
 
@@ -48,6 +61,10 @@ export const BPMNPoolNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/components/svgs/nodes/bpmnDiagram/BPMNSubprocessNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/bpmnDiagram/BPMNSubprocessNodeSVG.tsx
@@ -1,6 +1,9 @@
 import { CustomText } from "@/components"
 import { LINE_WIDTH } from "@/constants"
+import { useDiagramStore } from "@/store"
 import { SVGComponentProps } from "@/types/SVG"
+import { useShallow } from "zustand/shallow"
+import AssessmentIcon from "../../AssessmentIcon"
 
 export const BPMNSubprocessNodeSVG: React.FC<
   SVGComponentProps & {
@@ -14,7 +17,11 @@ export const BPMNSubprocessNodeSVG: React.FC<
   svgAttributes,
   transformScale,
   variant = "subprocess",
+  id,
+  showAssessmentResults = false,
 }) => {
+  const assessments = useDiagramStore(useShallow((state) => state.assessments))
+  const nodeScore = assessments[id]?.score
   const scaledWidth = width * (transformScale ?? 1)
   const scaledHeight = height * (transformScale ?? 1)
   const isTransaction = variant === "transaction"
@@ -117,6 +124,10 @@ export const BPMNSubprocessNodeSVG: React.FC<
       >
         {name}
       </CustomText>
+
+      {showAssessmentResults && (
+        <AssessmentIcon x={width - 15} y={-15} score={nodeScore} />
+      )}
     </svg>
   )
 }

--- a/library/lib/nodes/bpmn/BPMNAnnotation.tsx
+++ b/library/lib/nodes/bpmn/BPMNAnnotation.tsx
@@ -74,6 +74,7 @@ export function BPMNAnnotation({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNCallActivity.tsx
+++ b/library/lib/nodes/bpmn/BPMNCallActivity.tsx
@@ -75,6 +75,7 @@ export function BPMNCallActivity({
           id={id}
           name={data.name}
           variant="call"
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNDataObject.tsx
+++ b/library/lib/nodes/bpmn/BPMNDataObject.tsx
@@ -74,6 +74,7 @@ export function BPMNDataObject({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNDataStore.tsx
+++ b/library/lib/nodes/bpmn/BPMNDataStore.tsx
@@ -74,6 +74,7 @@ export function BPMNDataStore({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNEndEvent.tsx
+++ b/library/lib/nodes/bpmn/BPMNEndEvent.tsx
@@ -62,6 +62,7 @@ export function BPMNEndEvent({
           name={data.name}
           variant="end"
           eventType={data.eventType}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNGateway.tsx
+++ b/library/lib/nodes/bpmn/BPMNGateway.tsx
@@ -60,6 +60,7 @@ export function BPMNGateway({
           id={id}
           name={data.name}
           gatewayType={data.gatewayType}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNGroup.tsx
+++ b/library/lib/nodes/bpmn/BPMNGroup.tsx
@@ -74,6 +74,7 @@ export function BPMNGroup({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNIntermediateEvent.tsx
+++ b/library/lib/nodes/bpmn/BPMNIntermediateEvent.tsx
@@ -61,6 +61,7 @@ export function BPMNIntermediateEvent({
           name={data.name}
           variant="intermediate"
           eventType={data.eventType}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNPool.tsx
+++ b/library/lib/nodes/bpmn/BPMNPool.tsx
@@ -74,6 +74,7 @@ export function BPMNPool({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNStartEvent.tsx
+++ b/library/lib/nodes/bpmn/BPMNStartEvent.tsx
@@ -61,6 +61,7 @@ export function BPMNStartEvent({
           name={data.name}
           variant="start"
           eventType={data.eventType}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNSubprocess.tsx
+++ b/library/lib/nodes/bpmn/BPMNSubprocess.tsx
@@ -74,6 +74,7 @@ export function BPMNSubprocess({
           height={height}
           id={id}
           name={data.name}
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager

--- a/library/lib/nodes/bpmn/BPMNTransaction.tsx
+++ b/library/lib/nodes/bpmn/BPMNTransaction.tsx
@@ -75,6 +75,7 @@ export function BPMNTransaction({
           id={id}
           name={data.name}
           variant="transaction"
+          showAssessmentResults={!isDiagramModifiable}
         />
       </div>
       <PopoverManager


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

BPMN elements was not showing their assessment icons. This pr makes them show the assessment icon

This PR completes https://github.com/ls1intum/Apollon2/issues/xx

### Description

<!-- Describe your changes in detail -->

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Go to playground http://localhost:5173/playground
2. Create BPMN diagram element
3. Change mode to Assessment
4. Give feedback to each element
5. See Assessment Icons

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1568" height="1056" alt="Screenshot 2025-09-01 at 17 35 16" src="https://github.com/user-attachments/assets/0dea6efd-1b0e-45ab-972d-772980fbe6c5" />

