### PR TITLE
fix: have less operation while sharing states

### DIFF
--- a/library/lib/sync/yjsSyncClass.ts
+++ b/library/lib/sync/yjsSyncClass.ts
@@ -174,7 +174,16 @@ export class YjsSyncClass {
    *  Convert Uint8Array to Base64 string
    */
   static uint8ToBase64(uint8: Uint8Array): string {
-    return btoa(String.fromCharCode(...uint8))
+    // For large arrays, process in chunks to avoid stack overflow
+    const chunkSize = 8192 // Process 8KB at a time
+    let binary = ""
+
+    for (let i = 0; i < uint8.length; i += chunkSize) {
+      const chunk = uint8.slice(i, i + chunkSize)
+      binary += String.fromCharCode(...chunk)
+    }
+
+    return btoa(binary)
   }
 
   /**

--- a/library/lib/utils/storeUtils.ts
+++ b/library/lib/utils/storeUtils.ts
@@ -1,32 +1,3 @@
 export const deepEqual = <T>(a: T, b: T): boolean => {
-  // Strict equality check
-  if (a === b) return true
-
-  // Check if either is null or not an object
-  if (
-    a == null ||
-    typeof a !== "object" ||
-    b == null ||
-    typeof b !== "object"
-  ) {
-    return false
-  }
-
-  // Handle arrays
-  if (Array.isArray(a) !== Array.isArray(b)) return false
-
-  // Get keys
-  const keysA = Object.keys(a) as (keyof T)[]
-  const keysB = Object.keys(b) as (keyof T)[]
-
-  // Check if number of keys is different
-  if (keysA.length !== keysB.length) return false
-
-  // Check each key and value recursively
-  for (const key of keysA) {
-    if (!keysB.includes(key)) return false
-    if (!deepEqual(a[key], b[key])) return false
-  }
-
-  return true
+  return JSON.stringify(a) === JSON.stringify(b)
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When a user spams the input field sometimes we get the following error and sync is broken. 
We also need to add debounce or throttle for input fields to make less network calls while updating names
```
Uncaught RangeError: Maximum call stack size exceeded
    at YjsSyncClass.uint8ToBase64 (yjsSyncClass.ts:177:24)
  ```

This PR completes https://github.com/ls1intum/Apollon2/issues/xx

### Description

<!-- Describe your changes in detail -->

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a shared diagram
2. Edit the diagram by multiple users

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
