### PR TITLE
Fix export of multiplicity and association labels

### DIFF
--- a/library/lib/edges/labelTypes/EdgeMiddleLabels.tsx
+++ b/library/lib/edges/labelTypes/EdgeMiddleLabels.tsx
@@ -32,14 +32,17 @@ export const EdgeMiddleLabels = ({
   let transform = ""
   let offsetX = 0
   let offsetY = 0
+  let labelX = pathMiddlePosition.x
+  let labelY = pathMiddlePosition.y
+  let rotation: number | null = null
 
   if (isUseCasePath && sourcePoint && targetPoint) {
     const dx = targetPoint.x - sourcePoint.x
     const dy = targetPoint.y - sourcePoint.y
     const angle = Math.atan2(dy, dx) * (180 / Math.PI)
-    let rotation = angle
+    let computedRotation = angle
     if (angle > 90 || angle < -90) {
-      rotation = angle + 180
+      computedRotation = angle + 180
     }
 
     const offsetDistance = 15
@@ -54,20 +57,25 @@ export const EdgeMiddleLabels = ({
       offsetY = normalizedPerpY * offsetDistance
     }
 
-    const middleX = (sourcePoint.x + targetPoint.x) / 2 + offsetX
-    const middleY = (sourcePoint.y + targetPoint.y) / 2 + offsetY
-
-    transform = `translate(${middleX}px, ${middleY}px) translate(-50%, -50%) rotate(${rotation}deg)`
+    labelX = (sourcePoint.x + targetPoint.x) / 2 + offsetX
+    labelY = (sourcePoint.y + targetPoint.y) / 2 + offsetY
+    rotation = computedRotation
+    transform = `translate(${labelX}px, ${labelY}px) translate(-50%, -50%) rotate(${computedRotation}deg)`
   } else {
     offsetX = isMiddlePathHorizontal ? 0 : 10
     offsetY = isMiddlePathHorizontal ? +20 : 0
-
-    transform = `translate(${pathMiddlePosition.x + offsetX}px, ${pathMiddlePosition.y + offsetY}px) translate(-50%, -50%)`
+    labelX = pathMiddlePosition.x + offsetX
+    labelY = pathMiddlePosition.y + offsetY
+    transform = `translate(${labelX}px, ${labelY}px) translate(-50%, -50%)`
   }
 
   return (
     <EdgeLabelRenderer>
       <div
+        data-export-label-type="association"
+        data-export-x={labelX}
+        data-export-y={labelY}
+        data-export-rotation={rotation ?? undefined}
         style={{
           position: "absolute",
           transform: transform,


### PR DESCRIPTION
## Summary
- expose association label positioning data so exports can reconstruct the text in SVGs
- include full edge graphics and rebuild association label text when generating exported SVGs

## Testing
- npm run lint:lib

------
https://chatgpt.com/codex/tasks/task_b_68e4f7ddce54832abba32f8690905b32