### PR TITLE
Fix Safari marker updates by remounting edges

### DIFF
--- a/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
@@ -58,6 +58,7 @@ export const ActivityDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -84,12 +85,14 @@ export const ActivityDiagramEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
@@ -94,12 +94,14 @@ export const BPMNDiagramEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
@@ -71,6 +71,7 @@ export const ClassDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -97,12 +98,14 @@ export const ClassDiagramEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
@@ -59,6 +59,7 @@ export const CommunicationDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -85,12 +86,14 @@ export const CommunicationDiagramEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
@@ -130,6 +130,7 @@ export const ComponentDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -156,12 +157,14 @@ export const ComponentDiagramEdge = ({
   })
 
   const { strokeColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
@@ -132,6 +132,7 @@ export const DeploymentDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -158,12 +159,14 @@ export const DeploymentDiagramEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/FlowChartEdge.tsx
+++ b/library/lib/edges/edgeTypes/FlowChartEdge.tsx
@@ -58,6 +58,7 @@ export const FlowChartEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -84,12 +85,14 @@ export const FlowChartEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
@@ -57,6 +57,7 @@ export const ObjectDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -83,12 +84,14 @@ export const ObjectDiagramEdge = ({
   })
 
   const { strokeColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -56,6 +56,7 @@ export const PetriNetEdge = ({
     currentPath,
     overlayPath,
     markerEnd,
+    markerStart,
     strokeDashArray,
     sourcePoint,
     targetPoint,
@@ -79,12 +80,14 @@ export const PetriNetEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={tempReconnectPath || currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
+++ b/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
@@ -58,6 +58,7 @@ export const ReachabilityGraphEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     handleEndpointPointerDown,
@@ -84,12 +85,14 @@ export const ReachabilityGraphEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
@@ -78,6 +78,7 @@ export const SfcDiagramEdge = ({
     hasInitialCalculation,
     isReconnectingRef,
     markerEnd,
+    markerStart,
     strokeDashArray,
     handlePointerDown,
     isDiagramModifiable,
@@ -102,6 +103,7 @@ export const SfcDiagramEdge = ({
 
   const { isNegated, displayName, showBar } = getParsedEdgeData(data)
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   const labelPosition = {
     x: edgeData.isMiddlePathHorizontal
@@ -147,6 +149,7 @@ export const SfcDiagramEdge = ({
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={isReconnectingRef.current ? undefined : markerEnd}

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -44,6 +44,7 @@ export const SyntaxTreeEdge = ({
     currentPath,
     overlayPath,
     markerEnd,
+    markerStart,
     strokeDashArray,
     isDiagramModifiable,
   } = useStraightPathEdge({
@@ -61,12 +62,14 @@ export const SyntaxTreeEdge = ({
     targetHandleId,
   })
   const { strokeColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={markerEnd}

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -57,6 +57,7 @@ export const UseCaseEdge = ({
     currentPath,
     overlayPath,
     markerEnd,
+    markerStart,
     strokeDashArray,
     isDiagramModifiable,
   } = useStraightPathEdge({
@@ -75,12 +76,14 @@ export const UseCaseEdge = ({
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
+  const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
 
   return (
     <AssessmentSelectableWrapper elementId={id} asElement="g">
       <FeedbackDropzone elementId={id} asElement="path" elementType={type}>
         <g className="edge-container">
           <BaseEdge
+            key={markerKey}
             id={id}
             path={currentPath}
             markerEnd={markerEnd}


### PR DESCRIPTION
## Summary
- add marker-based keys to edge components so Safari remounts SVG markers when the edge type changes
- plumb markerStart through edge components where needed to support the new keys

## Testing
- npm run lint --workspace=@tumaet/apollon

------
https://chatgpt.com/codex/tasks/task_b_68e51fb0fdfc832ab0305fa2cdf5adf0