### PR TITLE
fix: Edge connectors are rendered below 20px for y-coordinate in readOnly mode

### DIFF
--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -209,16 +209,9 @@ export const useStepPathEdge = ({
   const computedPoints = useMemo(() => {
     const simplifiedPath = simplifySvgPath(basePath)
     const parsed = parseSvgPath(simplifiedPath)
-    let result = removeDuplicatePoints(parsed)
-
-    if (result.length === 2 && !isDiagramModifiable) {
-      result = result.map((point) => ({
-        ...point,
-        y: point.y + 20,
-      }))
-    }
+    const result = removeDuplicatePoints(parsed)
     return result
-  }, [basePath, isDiagramModifiable])
+  }, [basePath])
 
   const prevNodePositionsRef = useRef<{
     source: { x: number; y: number; parentId?: string }

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/apollon",
-  "version": "4.2.5-alpha.0",
+  "version": "4.2.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR completes https://github.com/ls1intum/Apollon2/issues/350

### Description

Removed the logic which adds extra space in y-coordinate when readOnly=true

### Screenshots
Consistent diagram in both mode
<img width="738" height="161" alt="Screenshot 2025-11-25 at 14 44 19" src="https://github.com/user-attachments/assets/9c2062f9-b85f-4048-bfd2-a64f607bc621" />

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
