### PR TITLE
fix: Close file menu when user selects export option

### DIFF
--- a/standalone/webapp/src/components/navbar/JsonFileImportButton.tsx
+++ b/standalone/webapp/src/components/navbar/JsonFileImportButton.tsx
@@ -5,7 +5,9 @@ import { useNavigate } from "react-router"
 import { importDiagram } from "@tumaet/apollon"
 import { log } from "@/logger"
 
-export const JsonFileImportButton: React.FC<{ close: () => void }> = (props) => {
+export const JsonFileImportButton: React.FC<{ close: () => void }> = (
+  props
+) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const createModel = usePersistenceModelStore((state) => state.createModel)
   const navigate = useNavigate()

--- a/standalone/webapp/src/components/navbar/NavbarFile.tsx
+++ b/standalone/webapp/src/components/navbar/NavbarFile.tsx
@@ -91,7 +91,12 @@ export const NavbarFile: FC<Props> = ({ color, handleCloseNavMenu }) => {
         <MenuItem onClick={handleStartFromTemplate}>
           Start from Template
         </MenuItem>
-        <MenuItem onClick={() => {openModal("LOAD_DIAGRAM"); closeMainMenu()}}>
+        <MenuItem
+          onClick={() => {
+            openModal("LOAD_DIAGRAM")
+            closeMainMenu()
+          }}
+        >
           Load Diagram
         </MenuItem>
         <JsonFileImportButton close={closeMainMenu} />


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon2! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR completes https://github.com/ls1intum/Apollon2/issues/363

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create any diagram
2. Go to File->Export->Choose any option
3. Export the diagram
4. The File menu dropdown should be closed.

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
