### PR TITLE
docs: document multi-domain support and deployment

### DIFF
--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -4,6 +4,52 @@ Deployment is through [GitHub Action triggers](https://github.com/ls1intum/Apoll
 
 Click on "Run workflow" dropdown and select the main branch, then run the workflow.
 
+## Deploy Workflow
+
+The deploy workflow supports three independent components:
+
+| Input | Default | What it deploys |
+|-------|---------|----------------|
+| **deploy-app** | true | Server + Webapp (every deploy) |
+| **deploy-db** | false | Redis database (only when infra changes) |
+| **deploy-proxy** | false | Caddy reverse proxy (only when proxy config changes) |
+
+Each component deploys to its own directory under `/opt/apollon/`:
+
+```
+/opt/apollon/
+├── app/    ← Server + Webapp (CI/CD)
+├── db/     ← Redis
+└── proxy/  ← Caddy
+```
+
+## GitHub Environment Variables
+
+Set these in the GitHub Environment (e.g., "Production"):
+
+| Type | Name | Example | Required |
+|------|------|---------|----------|
+| Variable | `VM_HOST` | `apollon2.aet.cit.tum.de` | Yes |
+| Variable | `VM_USERNAME` | `github_deployment` | Yes |
+| Variable | `DOMAIN` | `apollon2.aet.cit.tum.de` | Yes |
+| Secret | `VM_SSH_PRIVATE_KEY` | *(SSH key)* | Yes |
+
+`DOMAIN` supports multiple domains (Caddy serves them all):
+
+```
+# Single domain
+DOMAIN=apollon2.aet.cit.tum.de
+
+# Multiple domains (comma-separated)
+DOMAIN=apollon.ase.in.tum.de, apollon.ase.cit.tum.de, apollon.aet.cit.tum.de
+```
+
+## First-Time Deployment
+
+1. Set up the GitHub Environment variables above
+2. Run the deploy workflow with **all three boxes checked**
+3. The workflow creates directories, pulls images, and starts all services
+
 ## Run Docker Locally
 
 Make sure Docker is up and running.
@@ -26,15 +72,15 @@ Make sure Docker is up and running.
 
 ## Available Docker Compose Files
 
-The project uses a 3-file split architecture for production:
+Production (3-file split, each deployed independently):
 
 | File | Purpose | Lifecycle |
 |------|---------|-----------|
-| `docker/compose.proxy.yml` | Caddy reverse proxy | Deployed once, stays up during app deploys |
-| `docker/compose.db.yml` | Redis database | Deployed once, stays up during app deploys |
+| `docker/compose.proxy.yml` | Caddy reverse proxy | Deployed when proxy config changes |
+| `docker/compose.db.yml` | Redis database | Deployed when infra changes |
 | `docker/compose.app.yml` | Server + Webapp | Deployed via CI/CD on every merge |
 
-For local development:
+Local development:
 
 | File | Purpose |
 |------|---------|


### PR DESCRIPTION
## Summary

The Caddy proxy already supports multiple domains — Caddy natively handles comma-separated domains in `{$DOMAIN}`. No code change needed, just documentation.

### Multi-domain usage

Set `DOMAIN` in the GitHub Environment:

```bash
# apollon2 VM (single domain)
DOMAIN=apollon2.aet.cit.tum.de

# apollon VM (replaces v1 on all domains)
DOMAIN=apollon.ase.in.tum.de, apollon.ase.cit.tum.de, apollon.aet.cit.tum.de
```

### Docs added
- Complete deployment workflow guide (inputs, directory structure)
- GitHub Environment variables reference
- Multi-domain examples
- First-time deployment instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)